### PR TITLE
llm-mcp 형식검증(1~2) 불변식 문서/테스트 추가

### DIFF
--- a/docs/FORMAL-VERIFICATION.md
+++ b/docs/FORMAL-VERIFICATION.md
@@ -1,0 +1,60 @@
+# Formal Verification Scope (Phase 1-2)
+
+This document defines the formal-ish invariants we verify for:
+
+1) Protocol codec (Compact/Verbose/Base85/Zstd formats)
+2) Consensus and validation logic (Meta/Quorum/Pipeline policies)
+
+Non-goals:
+- External CLI reliability (codex/gemini/claude/ollama)
+- LLM output quality or truthfulness
+- Network/IO behavior outside the codec boundaries
+
+---
+
+## 1) Protocol Codec Invariants
+
+We treat `format_tool_result` + `decode_formatted_response` as the codec boundary.
+The invariants below must hold for all supported formats.
+
+### Invariants
+- Round-trip preservation:
+  - `status`, `model`, `tokens`, `result` are preserved after decode.
+- DSL correctness:
+  - Results containing `|` must decode without loss.
+- Auto selection:
+  - `< auto_compact_threshold` => Compact DSL (`RES|...`)
+  - `[auto_compact_threshold, auto_base85_threshold)` => Base85 (`A...`)
+  - `>= auto_base85_threshold` => Zstd (`S...`)
+- Unknown prefix and empty payload are rejected.
+
+### Covered By
+- `test/test_binaries.ml` (E2E codec roundtrip + special cases)
+- `test/test_msgpack_size.ml` (msgpack v1-v3 roundtrip)
+- `test/test_protocol_invariants.ml` (status/tokens/model preservation)
+
+---
+
+## 2) Consensus/Validation Logic Invariants
+
+We treat validators as deterministic functions for these guarantees.
+
+### Invariants
+- Determinism:
+  - For the same input, verdict is stable across runs.
+- Majority boundary (strict):
+  - `pass_count > n/2` is required to pass.
+- Weighted threshold:
+  - Weighted score must be `>= 0.5 * total_weight`.
+- Monotonic pass (majority):
+  - Adding a passing validator does not flip `pass -> fail`.
+
+### Covered By
+- `test/test_presets.ml` (Meta/Quorum invariants)
+
+---
+
+## Notes
+
+- These invariants only apply at the codec and validator layers.
+- For full-system reliability, use runtime checks and integration tests.

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 ; Core tests (no agent_core dependency)
 (tests
- (names test_types test_tools test_mcp_server test_binaries test_msgpack_size test_input_compression test_dictionary test_parallel test_cli_runner test_common test_mcp_session test_sse test_notification_sse test_run_log)
+ (names test_types test_tools test_mcp_server test_binaries test_msgpack_size test_protocol_invariants test_input_compression test_dictionary test_parallel test_cli_runner test_common test_mcp_session test_sse test_notification_sse test_run_log)
  (modules (:standard \ test_ollama_integration test_agent_core_eio test_validator_eio test_lwt_bridge test_presets test_spec_dsl test_validation_stack test_orchestration_eio test_cli_runner_eio test_tools_eio test_mcp_server_eio test_tool_parsers))
  (libraries llm_mcp alcotest alcotest-lwt lwt lwt.unix str zstd domainslib)
  (preprocess (pps lwt_ppx)))
@@ -65,4 +65,3 @@
 (test
  (name test_tool_parsers)
  (libraries llm_mcp.common alcotest))
-

--- a/test/test_protocol_invariants.ml
+++ b/test/test_protocol_invariants.ml
@@ -1,0 +1,38 @@
+(* Protocol codec invariants (Phase 1-2) *)
+
+open Alcotest
+open Llm_mcp.Types
+
+let decode_or_fail encoded =
+  match decode_formatted_response encoded with
+  | Ok r -> r
+  | Error e -> fail (Printf.sprintf "decode failed: %s" e)
+
+let assert_compact_fields ~expected ~actual =
+  check bool "status preserved" true (actual.status = expected.status);
+  check bool "model preserved" true (actual.model = expected.model);
+  check int "tokens preserved" expected.tokens actual.tokens;
+  check string "result preserved" expected.result actual.result
+
+let test_format_roundtrip_preserves_fields () =
+  let result : tool_result = {
+    model = "gemini";
+    returncode = 2;
+    response = "err|payload";
+    extra = [("tokens", "42")];
+  } in
+  let expected = tool_result_to_compact result in
+  let formats = [Compact; Binary; Base85; Compressed; ZstdDict; Auto] in
+  List.iter (fun format ->
+    let encoded = format_tool_result ~format result in
+    let decoded = decode_or_fail encoded in
+    assert_compact_fields ~expected ~actual:decoded
+  ) formats
+
+let () =
+  run "protocol invariants" [
+    "codec",
+    [
+      "formatted roundtrip preserves fields", `Quick, test_format_roundtrip_preserves_fields;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- 프로토콜/합의 불변식 문서화 및 커버리지 매핑 추가
- 프로토콜 코덱 roundtrip 불변식 테스트 추가
- 합의 로직 불변식 테스트 보강 및 test/dune 등록

## Testing
- dune runtest --root .
