### PR TITLE
feat(chain): add Mermaid execution support (WYSIWYE)

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -167,11 +167,17 @@ let prompt_chars_of_args (args : tool_args) =
   | Codex { prompt; _ }
   | Ollama { prompt; _ } -> String.length prompt
   | OllamaList -> 0  (* No prompt for list operation *)
-  | ChainRun { chain; _ } ->
-      (* Estimate chain size from JSON *)
-      String.length (Yojson.Safe.to_string chain)
-  | ChainValidate { chain } ->
-      String.length (Yojson.Safe.to_string chain)
+  | ChainRun { chain; mermaid; _ } ->
+      (* Estimate chain size from JSON or Mermaid *)
+      (match (chain, mermaid) with
+       | (Some c, _) -> String.length (Yojson.Safe.to_string c)
+       | (_, Some m) -> String.length m
+       | (None, None) -> 0)
+  | ChainValidate { chain; mermaid } ->
+      (match (chain, mermaid) with
+       | (Some c, _) -> String.length (Yojson.Safe.to_string c)
+       | (_, Some m) -> String.length m
+       | (None, None) -> 0)
 
 let split_once s ch =
   match String.index_opt s ch with


### PR DESCRIPTION
## Summary
- **WYSIWYE** (What You See Is What You Execute) - Mermaid diagrams that render AND execute
- `chain.run` and `chain.validate` MCP tools now accept either `chain` (JSON) or `mermaid` (string) parameter
- Enables visual workflow design that directly executes

## Changes
- `lib/types.ml`: Updated schemas with `oneOf` for JSON or Mermaid input
- `lib/tool_parsers.ml`: Parse both formats
- `lib/tools_eio.ml`: Route to `Chain_mermaid_parser` when mermaid provided
- `test/test_chain_mcp_eio.ml`: Added `test_mermaid_execution` test
- `test/test_mcp_server.ml`: Updated tool count (5 → 7)

## Example Usage
```json
{
  "name": "chain.run",
  "arguments": {
    "mermaid": "flowchart TD\n    A[\"llm:gemini\n    Analyze this code\"]\n    B[\"llm:claude\n    Review: {{A}}\"]\n    A --> B"
  }
}
```

## Test plan
- [ ] Verify `chain.run` with JSON input still works
- [ ] Verify `chain.run` with Mermaid input works
- [ ] Verify `chain.validate` with both inputs
- [ ] CI passes all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)