### PR TITLE
fix: Critical type safety improvements (빡센 코드리뷰 v2)

### DIFF
--- a/lib/chain_executor_eio.ml
+++ b/lib/chain_executor_eio.ml
@@ -1416,7 +1416,10 @@ and execute_evaluator ctx ~sw ~clock ~exec_fn ~tool_exec (parent : node)
             List.find_opt (fun (_, _, sc) -> sc >= t) filtered
         | WeightedRandom ->
             (* Simplified: just pick first (proper impl would use weighted random) *)
-            Some (List.hd filtered)
+            (* Safe: filtered is non-empty due to guard at line 1397 *)
+            match filtered with
+            | first :: _ -> Some first
+            | [] -> None  (* Unreachable but type-safe *)
       in
       match selected with
       | None ->


### PR DESCRIPTION
## Summary
- **validator_eio.ml**: Fail-fast on empty validators list
- **chain_compiler.ml**: Detect missing dependencies with descriptive error
- **chain_executor_eio.ml**: Pattern matching for WeightedRandom selection

## Critical Bugs Fixed

### 1. Empty Validators Crash (validator_eio.ml)
```ocaml
(* BEFORE - cryptic crash *)
let first = List.hd results  (* 💥 Failure "hd" *)

(* AFTER - clear error *)
if validators = [] then
  failwith "quorum: validators list cannot be empty"
```

### 2. Missing Dependency Crash (chain_compiler.ml)
```ocaml
(* BEFORE - Not_found exception *)
let current = Hashtbl.find reverse_deps dep  (* 💥 if dep doesn't exist *)

(* AFTER - descriptive error *)
match Hashtbl.find_opt reverse_deps dep with
| Some current -> ...
| None -> missing_deps := (node, dep) :: !missing_deps
(* Returns: "Missing dependencies: 'node1' depends on unknown node 'missing'" *)
```

### 3. Parse Don't Validate (chain_executor_eio.ml)
```ocaml
(* BEFORE - relies on external guard *)
Some (List.hd filtered)

(* AFTER - type-safe pattern matching *)
match filtered with
| first :: _ -> Some first
| [] -> None
```

## Design Decision
Used `failwith` for empty validators because:
1. Empty validators is a programmer error, not runtime condition
2. Fail-fast catches configuration bugs early
3. Clear error message aids debugging

## Test plan
- [x] All existing tests pass (`dune runtest`)
- [x] Build succeeds (`dune build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)