### PR TITLE
chore: Remove unused compact-protocol dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,6 @@
   ; External dependencies (opam pin)
   (mcp_protocol (>= 0.1.0))
   (grpc-direct (>= 0.1.0))
-  (compact-protocol (>= 0.1.0))
   ; Standard dependencies
   (yojson (>= 2.0))
   (cmdliner (>= 1.1))

--- a/llm_mcp.opam
+++ b/llm_mcp.opam
@@ -15,7 +15,6 @@ depends: [
   "dune" {>= "3.13" & >= "3.13"}
   "mcp_protocol" {>= "0.1.0"}
   "grpc-direct" {>= "0.1.0"}
-  "compact-protocol" {>= "0.1.0"}
   "yojson" {>= "2.0"}
   "cmdliner" {>= "1.1"}
   "ppx_deriving_yojson" {>= "3.6"}


### PR DESCRIPTION
## Summary
- Remove compact-protocol from dependencies (was never used)

## Why
Reducing external dependencies for easier public adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)