### PR TITLE
chain.run/orchestrate에 MASC 훅 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ curl -X POST http://localhost:8932/mcp -d '{
 
 상세: [CLAUDE.md](CLAUDE.md), [docs/PRESETS.md](docs/PRESETS.md)
 
+## MASC Hook (optional)
+
+`chain.run`/`chain.orchestrate` 실행 시 MASC join/heartbeat/leave를 자동으로 수행합니다.
+
+```bash
+LLM_MCP_MASC_HOOK=true
+LLM_MCP_MASC_AGENT=llm-mcp
+LLM_MCP_MASC_HEARTBEAT_SEC=30
+```
+
+요구사항:
+- `~/.mcp.json`에 `masc` 서버 등록 필요
+
 ## 개발
 
 ```bash


### PR DESCRIPTION
## 요약\n- chain.run/orchestrate/resume 실행 시 MASC join/heartbeat/leave opt-in 훅 추가\n- env: LLM_MCP_MASC_HOOK / LLM_MCP_MASC_AGENT / LLM_MCP_MASC_HEARTBEAT_SEC\n- README에 사용법 추가\n\n## 검증\n- chain.run 호출 시 MASC events에 agent_join 기록 확인\n