### PR TITLE
Figma 요약 fallback 및 Claude 기본 모델 opus

### DIFF
--- a/data/chains/figma-to-component-spec.json
+++ b/data/chains/figma-to-component-spec.json
@@ -1,0 +1,202 @@
+{
+  "id": "figma-to-component-spec",
+  "name": "Figma → Component Spec (JSON)",
+  "description": "Figma summary를 기반으로 컴포넌트 스펙(JSON)을 생성합니다. 실패 시 fallback JSON을 반환합니다.",
+  "version": "1.0.0",
+  "nodes": [
+    {
+      "id": "flow",
+      "type": "pipeline",
+      "nodes": [
+        {
+          "id": "summary",
+          "type": "tool",
+          "tool": {
+            "name": "figma.figma_get_node_summary",
+            "args": {
+              "url": "{{input.url}}",
+              "max_children": 10
+            }
+          }
+        },
+        {
+          "id": "summary-json",
+          "type": "adapter",
+          "input_ref": "summary",
+          "transform": {
+            "type": "parse_json"
+          },
+          "on_error": "fail"
+        },
+        {
+          "id": "safe",
+          "type": "fallback",
+          "primary": {
+            "id": "build",
+            "type": "retry",
+            "max_attempts": 1,
+            "backoff": "constant:0.7",
+            "retry_on": [
+              "Schema validation failed",
+              "No JSON object/array found",
+              "Not valid JSON",
+              "Invalid JSON",
+              "Timeout"
+            ],
+            "node": {
+              "id": "primary-flow",
+              "type": "pipeline",
+              "nodes": [
+                {
+                  "id": "spec-gemini-llm",
+                  "type": "tool",
+                  "tool": {
+                    "name": "gemini",
+                    "args": {
+                      "model": "gemini-3-pro-preview",
+                      "thinking_level": "high",
+                      "timeout": 60,
+                      "stream": false,
+                      "prompt": "Return ONLY valid JSON.\n\nSUMMARY(JSON):\n{{summary-json}}\n\nOUTPUT JSON (exact keys):\n{\n  \"component_name\": string,\n  \"component_type\": string,\n  \"layout\": { \"type\": string, \"notes\": string },\n  \"tokens\": { \"colors\": [string], \"spacing\": [string], \"typography\": [string] },\n  \"texts\": [string],\n  \"structure\": [string],\n  \"implementation_notes\": [string]\n}"
+                    }
+                  }
+                },
+                {
+                  "id": "json-only",
+                  "type": "adapter",
+                  "input_ref": "spec-gemini-llm",
+                  "transform": {
+                    "type": "chain",
+                    "transforms": [
+                      { "type": "custom", "name": "extract_json" },
+                      { "type": "validate_schema", "schema": "{\"type\":\"object\",\"required\":[\"component_name\",\"component_type\",\"layout\",\"tokens\",\"texts\",\"structure\",\"implementation_notes\"]}" },
+                      { "type": "parse_json" }
+                    ]
+                  },
+                  "on_error": "fail"
+                }
+              ]
+            }
+          },
+          "fallbacks": [
+            {
+              "id": "repair-gemini",
+              "type": "pipeline",
+              "nodes": [
+                {
+                  "id": "repair-gemini-llm",
+                  "type": "tool",
+                  "tool": {
+                    "name": "gemini",
+                    "args": {
+                      "model": "gemini-3-pro-preview",
+                      "thinking_level": "high",
+                      "timeout": 60,
+                      "stream": false,
+                      "prompt": "Return ONLY valid JSON. No markdown, no extra text.\nIf unknown, use empty string or empty array, but NEVER omit keys.\n\nSUMMARY(JSON):\n{{summary-json}}\n\nRAW_OUTPUT:\n{{spec-gemini-llm}}\n\nOUTPUT JSON (exact keys):\n{\n  \"component_name\": string,\n  \"component_type\": string,\n  \"layout\": { \"type\": string, \"notes\": string },\n  \"tokens\": { \"colors\": [string], \"spacing\": [string], \"typography\": [string] },\n  \"texts\": [string],\n  \"structure\": [string],\n  \"implementation_notes\": [string]\n}"
+                    }
+                  }
+                },
+                {
+                  "id": "json-only-repair",
+                  "type": "adapter",
+                  "input_ref": "repair-gemini-llm",
+                  "transform": {
+                    "type": "chain",
+                    "transforms": [
+                      { "type": "custom", "name": "extract_json" },
+                      { "type": "validate_schema", "schema": "{\"type\":\"object\",\"required\":[\"component_name\",\"component_type\",\"layout\",\"tokens\",\"texts\",\"structure\",\"implementation_notes\"]}" },
+                      { "type": "parse_json" }
+                    ]
+                  },
+                  "on_error": "fail"
+                }
+              ]
+            },
+            {
+              "id": "spec-claude",
+              "type": "pipeline",
+              "nodes": [
+                {
+                  "id": "spec-claude-llm",
+                  "type": "tool",
+                  "tool": {
+                    "name": "claude-cli",
+                    "args": {
+                      "model": "opus",
+                      "output_format": "json",
+                      "system_prompt": "Return ONLY valid JSON. No extra text.",
+                      "timeout": 60,
+                      "prompt": "You MUST return a JSON object that matches the exact schema.\nIf unknown, use empty string or empty array, but NEVER omit keys.\n\nSUMMARY(JSON):\n{{summary-json}}\n\nOUTPUT JSON (exact keys):\n{\n  \"component_name\": string,\n  \"component_type\": string,\n  \"layout\": { \"type\": string, \"notes\": string },\n  \"tokens\": { \"colors\": [string], \"spacing\": [string], \"typography\": [string] },\n  \"texts\": [string],\n  \"structure\": [string],\n  \"implementation_notes\": [string]\n}"
+                    }
+                  }
+                },
+                {
+                  "id": "json-only-claude",
+                  "type": "adapter",
+                  "input_ref": "spec-claude-llm",
+                  "transform": {
+                    "type": "chain",
+                    "transforms": [
+                      { "type": "custom", "name": "extract_json" },
+                      { "type": "validate_schema", "schema": "{\"type\":\"object\",\"required\":[\"component_name\",\"component_type\",\"layout\",\"tokens\",\"texts\",\"structure\",\"implementation_notes\"]}" },
+                      { "type": "parse_json" }
+                    ]
+                  },
+                  "on_error": "fail"
+                }
+              ]
+            },
+            {
+              "id": "summary-to-spec",
+              "type": "adapter",
+              "input_ref": "summary-json",
+              "transform": {
+                "type": "chain",
+                "transforms": [
+                  { "type": "custom", "name": "figma_summary_to_spec" },
+                  { "type": "parse_json" }
+                ]
+              },
+              "on_error": "fail"
+            },
+            {
+              "id": "empty-json",
+              "type": "adapter",
+              "input_ref": "summary-json",
+              "transform": {
+                "type": "chain",
+                "transforms": [
+                  { "type": "template", "template": "{\"component_name\":\"\",\"component_type\":\"\",\"layout\":{\"type\":\"\",\"notes\":\"\"},\"tokens\":{\"colors\":[],\"spacing\":[],\"typography\":[]},\"texts\":[],\"structure\":[],\"implementation_notes\":[]}" },
+                  { "type": "parse_json" }
+                ]
+              },
+              "on_error": "fail"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "output": "flow",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "url": {
+        "type": "string",
+        "description": "Figma node URL (예: https://www.figma.com/design/...?...node-id=2089-10737)"
+      }
+    },
+    "required": ["url"]
+  },
+  "output_schema": {
+    "type": "object",
+    "description": "Component spec JSON"
+  },
+  "metadata": {
+    "author": "Chain Engine",
+    "tags": ["figma", "component", "spec", "json"],
+    "estimated_duration_sec": 30,
+    "estimated_cost_usd": 0.02
+  }
+}

--- a/lib/agent_core_eio/claude_cli_backend_eio.ml
+++ b/lib/agent_core_eio/claude_cli_backend_eio.ml
@@ -11,7 +11,7 @@
       Eio.Switch.run @@ fun sw ->
         let proc_mgr = Eio.Stdenv.process_mgr env in
         let config = Claude_cli_backend_eio.{
-          model = "sonnet";  (* or "opus", "haiku" *)
+          model = "opus";  (* or "sonnet", "haiku" *)
           timeout_ms = Some 120_000;
           system_prompt = None;
           allowed_tools = None;
@@ -28,7 +28,7 @@ open Agent_types
 (** {1 Configuration} *)
 
 type config = {
-  model : string;              (** Model alias: "sonnet", "opus", "haiku" *)
+  model : string;              (** Model alias: "opus", "sonnet", "haiku" *)
   timeout_ms : int option;     (** Command timeout in ms (None = no timeout) *)
   system_prompt : string option;  (** Optional system prompt override *)
   allowed_tools : string list option;  (** Allowed tools (None = default) *)
@@ -36,7 +36,7 @@ type config = {
 }
 
 let default_config = {
-  model = "sonnet";
+  model = "opus";
   timeout_ms = Some 120_000;  (* 2 minutes default *)
   system_prompt = None;
   allowed_tools = None;

--- a/tools/chain-editor/index.html
+++ b/tools/chain-editor/index.html
@@ -820,6 +820,193 @@
           ],
           output: 'figma_component_flow'
         }
+      },
+      'figma-spec-json': {
+        nodes: [
+          { id: 'S', type: 'tool', label: 'summary', x: 60, y: 120, config: 'Tool:figma:figma_get_node_summary' },
+          { id: 'C', type: 'tool', label: 'spec', x: 320, y: 120, config: 'Tool:claude-cli' },
+          { id: 'J', type: 'adapter', label: 'json', x: 580, y: 120, config: 'Adapter:extract_json+schema' }
+        ],
+        connections: [
+          ['S', 'C'],
+          ['C', 'J']
+        ],
+        chain: {
+          id: 'figma-to-component-spec',
+          name: 'Figma → Component Spec (JSON)',
+          version: '1.0.0',
+          nodes: [
+            {
+              id: 'flow',
+              type: 'pipeline',
+              nodes: [
+                {
+                  id: 'summary',
+                  type: 'tool',
+                  tool: {
+                    name: 'figma.figma_get_node_summary',
+                    args: { url: '{{input.url}}', max_children: 10 }
+                  }
+                },
+                {
+                  id: 'summary-json',
+                  type: 'adapter',
+                  input_ref: 'summary',
+                  transform: { type: 'parse_json' },
+                  on_error: 'fail'
+                },
+                {
+                  id: 'safe',
+                  type: 'fallback',
+                  primary: {
+                    id: 'build',
+                    type: 'retry',
+                    max_attempts: 1,
+                    backoff: 'constant:0.7',
+                    retry_on: [
+                      'Schema validation failed',
+                      'No JSON object/array found',
+                      'Not valid JSON',
+                      'Invalid JSON',
+                      'Timeout'
+                    ],
+                    node: {
+                      id: 'primary-flow',
+                      type: 'pipeline',
+                      nodes: [
+                        {
+                          id: 'spec-gemini-llm',
+                          type: 'tool',
+                          tool: {
+                            name: 'gemini',
+                            args: {
+                              model: 'gemini-3-pro-preview',
+                              thinking_level: 'high',
+                              timeout: 60,
+                              stream: false,
+                              prompt: 'Return ONLY valid JSON.\\n\\nSUMMARY(JSON):\\n{{summary-json}}\\n\\nOUTPUT JSON (exact keys):\\n{\\n  \"component_name\": string,\\n  \"component_type\": string,\\n  \"layout\": { \"type\": string, \"notes\": string },\\n  \"tokens\": { \"colors\": [string], \"spacing\": [string], \"typography\": [string] },\\n  \"texts\": [string],\\n  \"structure\": [string],\\n  \"implementation_notes\": [string]\\n}'
+                            }
+                          }
+                        },
+                        {
+                          id: 'json-only',
+                          type: 'adapter',
+                          input_ref: 'spec-gemini-llm',
+                          transform: {
+                            type: 'chain',
+                            transforms: [
+                              { type: 'custom', name: 'extract_json' },
+                              { type: 'validate_schema', schema: '{\"type\":\"object\",\"required\":[\"component_name\",\"component_type\",\"layout\",\"tokens\",\"texts\",\"structure\",\"implementation_notes\"]}' },
+                              { type: 'parse_json' }
+                            ]
+                          },
+                          on_error: 'fail'
+                        }
+                      ]
+                    }
+                  },
+                  fallbacks: [
+                    {
+                      id: 'repair-gemini',
+                      type: 'pipeline',
+                      nodes: [
+                        {
+                          id: 'repair-gemini-llm',
+                          type: 'tool',
+                          tool: {
+                            name: 'gemini',
+                            args: {
+                              model: 'gemini-3-pro-preview',
+                              thinking_level: 'high',
+                              timeout: 60,
+                              stream: false,
+                              prompt: 'Return ONLY valid JSON. No markdown, no extra text.\\nIf unknown, use empty string or empty array, but NEVER omit keys.\\n\\nSUMMARY(JSON):\\n{{summary-json}}\\n\\nRAW_OUTPUT:\\n{{spec-gemini-llm}}\\n\\nOUTPUT JSON (exact keys):\\n{\\n  \"component_name\": string,\\n  \"component_type\": string,\\n  \"layout\": { \"type\": string, \"notes\": string },\\n  \"tokens\": { \"colors\": [string], \"spacing\": [string], \"typography\": [string] },\\n  \"texts\": [string],\\n  \"structure\": [string],\\n  \"implementation_notes\": [string]\\n}'
+                            }
+                          }
+                        },
+                        {
+                          id: 'json-only-repair',
+                          type: 'adapter',
+                          input_ref: 'repair-gemini-llm',
+                          transform: {
+                            type: 'chain',
+                            transforms: [
+                              { type: 'custom', name: 'extract_json' },
+                              { type: 'validate_schema', schema: '{\"type\":\"object\",\"required\":[\"component_name\",\"component_type\",\"layout\",\"tokens\",\"texts\",\"structure\",\"implementation_notes\"]}' },
+                              { type: 'parse_json' }
+                            ]
+                          },
+                          on_error: 'fail'
+                        }
+                      ]
+                    },
+                    {
+                      id: 'spec-claude',
+                      type: 'pipeline',
+                      nodes: [
+                        {
+                          id: 'spec-claude-llm',
+                          type: 'tool',
+                          tool: {
+                            name: 'claude-cli',
+                            args: {
+                              model: 'opus',
+                              output_format: 'json',
+                              system_prompt: 'Return ONLY valid JSON. No extra text.',
+                              timeout: 60,
+                              prompt: 'You MUST return a JSON object that matches the exact schema.\\nIf unknown, use empty string or empty array, but NEVER omit keys.\\n\\nSUMMARY(JSON):\\n{{summary-json}}\\n\\nOUTPUT JSON (exact keys):\\n{\\n  \"component_name\": string,\\n  \"component_type\": string,\\n  \"layout\": { \"type\": string, \"notes\": string },\\n  \"tokens\": { \"colors\": [string], \"spacing\": [string], \"typography\": [string] },\\n  \"texts\": [string],\\n  \"structure\": [string],\\n  \"implementation_notes\": [string]\\n}'
+                            }
+                          }
+                        },
+                        {
+                          id: 'json-only-claude',
+                          type: 'adapter',
+                          input_ref: 'spec-claude-llm',
+                          transform: {
+                            type: 'chain',
+                            transforms: [
+                              { type: 'custom', name: 'extract_json' },
+                              { type: 'validate_schema', schema: '{\"type\":\"object\",\"required\":[\"component_name\",\"component_type\",\"layout\",\"tokens\",\"texts\",\"structure\",\"implementation_notes\"]}' },
+                              { type: 'parse_json' }
+                            ]
+                          },
+                          on_error: 'fail'
+                        }
+                      ]
+                    },
+                    {
+                      id: 'summary-to-spec',
+                      type: 'adapter',
+                      input_ref: 'summary-json',
+                      transform: {
+                        type: 'chain',
+                        transforms: [
+                          { type: 'custom', name: 'figma_summary_to_spec' },
+                          { type: 'parse_json' }
+                        ]
+                      },
+                      on_error: 'fail'
+                    },
+                    {
+                      id: 'empty-json',
+                      type: 'adapter',
+                      input_ref: 'summary-json',
+                      transform: {
+                        type: 'chain',
+                        transforms: [
+                          { type: 'template', template: '{\"component_name\":\"\",\"component_type\":\"\",\"layout\":{\"type\":\"\",\"notes\":\"\"},\"tokens\":{\"colors\":[],\"spacing\":[],\"typography\":[]},\"texts\":[],\"structure\":[],\"implementation_notes\":[]}' },
+                          { type: 'parse_json' }
+                        ]
+                      },
+                      on_error: 'fail'
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          output: 'flow'
+        }
       }
     };
 
@@ -830,7 +1017,8 @@
       research: { title: '🔍 Deep Research', summary: '8 nodes · multi-source', tags: ['research'] },
       simple: { title: '⚡ Simple Pipeline', summary: '3 nodes · A→B→C', tags: ['simple'] },
       'figma-prototype': { title: '🎨 Figma → Prototype', summary: '6 nodes · figma-to-prototype', tags: ['figma', 'prototype'] },
-      'figma-component': { title: '🧩 Figma → Web Component', summary: '6 nodes · figma-to-web-component', tags: ['figma', 'web'] }
+      'figma-component': { title: '🧩 Figma → Web Component', summary: '6 nodes · figma-to-web-component', tags: ['figma', 'web'] },
+      'figma-spec-json': { title: '🧩 Figma → Component Spec (JSON)', summary: '3 nodes · strict JSON + fallback', tags: ['figma', 'spec', 'json'] }
     };
 
     function renderPresetList(filter = '') {


### PR DESCRIPTION
## 요약\n- Figma summary 기반 deterministic spec fallback 추가\n- Claude CLI 전역 기본 모델을 opus로 통일\n- 체인 프리셋 정의 동기화\n\n## 테스트\n- dune build ./bin/main_eio.exe\n- chain.run: figma-to-component-spec (summary fallback 확인)\n\n## 참고\n- Claude API 사용량 제한 시에도 summary-to-spec fallback로 스펙 JSON 생성 가능