### PR TITLE
Decouple runtime defaults from local machine assumptions

### DIFF
--- a/lib/agent_core_eio/ollama_backend_eio.ml
+++ b/lib/agent_core_eio/ollama_backend_eio.ml
@@ -10,7 +10,7 @@
       Eio.Switch.run @@ fun sw ->
         let net = Eio.Stdenv.net env in
         let config = Ollama_backend_eio.{
-          base_url = "http://127.0.0.1:11434";
+          base_url = Sys.getenv "OLLAMA_BASE_URL";
           model = "llama3";
           temperature = 0.7;
           stream = false;
@@ -35,8 +35,13 @@ type config = {
   timeout_ms : int option; (** Request timeout in ms (None = no timeout) *)
 }
 
+let default_base_url () =
+  match Sys.getenv_opt "OLLAMA_BASE_URL" with
+  | Some value when String.trim value <> "" -> String.trim value
+  | _ -> failwith "OLLAMA_BASE_URL is required"
+
 let default_config = {
-  base_url = "http://127.0.0.1:11434";
+  base_url = default_base_url ();
   model = "llama3";
   temperature = 0.7;
   stream = false;
@@ -221,7 +226,7 @@ let is_final resp =
 (** {1 Utility Functions} *)
 
 (** Check if Ollama server is reachable *)
-let health_check ~sw ~net ?(base_url = "http://127.0.0.1:11434") () =
+let health_check ~sw ~net ?(base_url = default_base_url ()) () =
   let uri = Uri.of_string (base_url ^ "/api/tags") in
   try
     let client = Cohttp_eio.Client.make ~https:None net in
@@ -232,7 +237,7 @@ let health_check ~sw ~net ?(base_url = "http://127.0.0.1:11434") () =
     false
 
 (** List available models from Ollama *)
-let list_models ~sw ~net ?(base_url = "http://127.0.0.1:11434") () =
+let list_models ~sw ~net ?(base_url = default_base_url ()) () =
   let uri = Uri.of_string (base_url ^ "/api/tags") in
   try
     let client = Cohttp_eio.Client.make ~https:None net in

--- a/lib/agent_core_eio/ollama_backend_eio.ml
+++ b/lib/agent_core_eio/ollama_backend_eio.ml
@@ -41,7 +41,10 @@ let default_base_url () =
   | _ -> failwith "OLLAMA_BASE_URL is required"
 
 let default_config = {
-  base_url = default_base_url ();
+  base_url =
+    (match Sys.getenv_opt "OLLAMA_BASE_URL" with
+     | Some value when String.trim value <> "" -> String.trim value
+     | _ -> "");
   model = "llama3";
   temperature = 0.7;
   stream = false;

--- a/lib/agent_loop_eio.ml
+++ b/lib/agent_loop_eio.ml
@@ -18,7 +18,10 @@ open Ollama_parser
 let default_max_turns = 10
 
 (** Ollama API endpoint *)
-let ollama_base_url = "http://127.0.0.1:11434"
+let ollama_base_url () =
+  match Sys.getenv_opt "OLLAMA_BASE_URL" with
+  | Some value when String.trim value <> "" -> String.trim value
+  | _ -> failwith "OLLAMA_BASE_URL is required"
 
 (** Conversation message type *)
 type message = {
@@ -81,7 +84,7 @@ let build_continuation_request state tool_results =
 
 (** Call Ollama chat API using Eio HTTP client *)
 let call_ollama_chat ~sw ~net request =
-  let uri = Uri.of_string (ollama_base_url ^ "/api/chat") in
+  let uri = Uri.of_string (ollama_base_url () ^ "/api/chat") in
   let body = Yojson.Safe.to_string request in
   let headers = Cohttp.Header.init_with "Content-Type" "application/json" in
   let body_source = Eio.Flow.string_source body in

--- a/lib/chain_executor_eio.ml
+++ b/lib/chain_executor_eio.ml
@@ -359,8 +359,9 @@ let execute_llm_node ctx ~(exec_fn : exec_fn) ~(node : node) (llm : node_type) :
 
 (** MASC MCP endpoint - configurable via MASC_MCP_URL env var *)
 let _masc_mcp_url () =
-  try Sys.getenv "MASC_MCP_URL"
-  with Not_found -> "http://localhost:7432/mcp"
+  match Sys.getenv_opt "MASC_MCP_URL" with
+  | Some value when String.trim value <> "" -> value
+  | _ -> failwith "MASC_MCP_URL is required"
 
 (** Get MASC agent name from env or default *)
 let masc_agent_name () =

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -20,7 +20,7 @@ let repo_root_opt () =
   | Some root -> Some root
   | None -> Sys.getenv_opt "DUNE_SOURCEROOT" |> trim_opt
 
-let me_root () =
+let me_root =
   match repo_root_opt () with
   | Some root -> root
   | None ->
@@ -92,7 +92,7 @@ let date_str () =
 
 (** Build path relative to the configured workspace root. *)
 let me_path parts =
-  List.fold_left Filename.concat (me_root ()) parts
+  List.fold_left Filename.concat me_root parts
 
 (** Safe file read - returns None on error.
     Uses In_channel.with_open_text for automatic resource cleanup. *)

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -20,7 +20,7 @@ let repo_root_opt () =
   | Some root -> Some root
   | None -> Sys.getenv_opt "DUNE_SOURCEROOT" |> trim_opt
 
-let me_root =
+let me_root () =
   match repo_root_opt () with
   | Some root -> root
   | None ->
@@ -92,7 +92,7 @@ let date_str () =
 
 (** Build path relative to the configured workspace root. *)
 let me_path parts =
-  List.fold_left Filename.concat me_root parts
+  List.fold_left Filename.concat (me_root ()) parts
 
 (** Safe file read - returns None on error.
     Uses In_channel.with_open_text for automatic resource cleanup. *)

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -8,10 +8,24 @@
     - File I/O helpers (with proper resource cleanup)
 *)
 
-(** Get ME_ROOT environment variable, defaulting to ~/me *)
+(** Resolve repo root from explicit runtime config only. *)
+let trim_opt = function
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then None else Some trimmed
+  | None -> None
+
+let repo_root_opt () =
+  match Sys.getenv_opt "LLM_MCP_REPO_ROOT" |> trim_opt with
+  | Some root -> Some root
+  | None -> Sys.getenv_opt "DUNE_SOURCEROOT" |> trim_opt
+
 let me_root =
-  try Sys.getenv "ME_ROOT"
-  with Not_found -> Filename.concat (Sys.getenv "HOME") "me"
+  match repo_root_opt () with
+  | Some root -> root
+  | None ->
+      failwith
+        "LLM_MCP_REPO_ROOT is required (tests may use DUNE_SOURCEROOT)"
 
 (** Ensure directory exists, creating parent directories as needed *)
 let rec ensure_dir path =
@@ -76,7 +90,7 @@ let date_str () =
   Printf.sprintf "%04d-%02d-%02d"
     (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
 
-(** Build path relative to ME_ROOT *)
+(** Build path relative to the configured workspace root. *)
 let me_path parts =
   List.fold_left Filename.concat me_root parts
 

--- a/lib/dictionary.ml
+++ b/lib/dictionary.ml
@@ -424,40 +424,17 @@ let decompress_with_dict (dict : t) (data : string) : (string, string) result =
 
 (** Directory for pre-trained dictionaries *)
 let dict_dir () : string =
-  let default_me_root () =
-    let home = Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp" in
-    Filename.concat home "me"
-  in
-  let find_repo_root me_root =
+  let repo_root_opt () =
     match Sys.getenv_opt "LLM_MCP_REPO_ROOT" with
-    | Some path -> Some path
-    | None ->
-        let candidates =
-          [Filename.concat me_root "llm-mcp"; Filename.concat me_root "workspace/llm-mcp"]
-        in
-        let rec find_in_workspace workspace entries =
-          match entries with
-          | [] -> None
-          | dir :: rest ->
-              let candidate = Filename.concat (Filename.concat workspace dir) "llm-mcp" in
-              if Sys.file_exists candidate then Some candidate
-              else find_in_workspace workspace rest
-        in
-        (match List.find_opt Sys.file_exists candidates with
-        | Some path -> Some path
-        | None ->
-            let workspace = Filename.concat me_root "workspace" in
-            (match Sys.readdir workspace with
-            | entries -> find_in_workspace workspace (Array.to_list entries)
-            | exception _ -> None))
+    | Some path when String.trim path <> "" -> Some (String.trim path)
+    | _ -> None
   in
   match Sys.getenv_opt "LLM_MCP_DICTS_DIR" with
   | Some dir -> dir
   | None ->
-      let me_root = Sys.getenv_opt "ME_ROOT" |> Option.value ~default:(default_me_root ()) in
-      (match find_repo_root me_root with
+      (match repo_root_opt () with
       | Some root -> Filename.concat root "data/dicts"
-      | None -> Filename.concat (Sys.getcwd ()) "data/dicts")
+      | None -> failwith "LLM_MCP_DICTS_DIR or LLM_MCP_REPO_ROOT is required")
 
 (** Load pre-trained dictionary for content type *)
 let load_for_type (content_type : content_type) : t option =

--- a/lib/dictionary.ml
+++ b/lib/dictionary.ml
@@ -439,10 +439,13 @@ let dict_dir () : string =
 (** Load pre-trained dictionary for content type *)
 let load_for_type (content_type : content_type) : t option =
   let name = string_of_content_type content_type in
-  let path = Filename.concat (dict_dir ()) (name ^ ".zdict") in
-  match load path with
-  | Ok d -> Some d
-  | Error _ -> None
+  try
+    let path = Filename.concat (dict_dir ()) (name ^ ".zdict") in
+    match load path with
+    | Ok d -> Some d
+    | Error _ -> None
+  with Failure _ ->
+    None
 
 (** Load default (mixed) dictionary *)
 let load_default () : t option =
@@ -456,18 +459,18 @@ let is_dict_compressed (data : string) : bool =
 
 (** Compress with auto-detected dictionary *)
 let compress_auto ?(level = 3) (data : string) : string =
+  let len = String.length data in
+  if len < min_payload_size then data
+  else
   let content_type = detect_content_type data in
   match load_for_type content_type with
   | Some dict -> compress_with_dict dict ~level data
   | None ->
       (* Fall back to generic zstd *)
-      let len = String.length data in
-      if len < min_payload_size then data
-      else
-        try
-          let compressed = Zstd.compress ~level data in
-          if String.length compressed < len then compressed else data
-        with _ -> data
+      try
+        let compressed = Zstd.compress ~level data in
+        if String.length compressed < len then compressed else data
+      with _ -> data
 
 (** Decompress with auto-detected dictionary *)
 let decompress_auto (data : string) : string =

--- a/lib/langfuse.ml
+++ b/lib/langfuse.ml
@@ -10,7 +10,7 @@
     환경변수:
     - LANGFUSE_SECRET_KEY: API 시크릿 키
     - LANGFUSE_PUBLIC_KEY: API 퍼블릭 키
-    - LANGFUSE_HOST: Langfuse 서버 URL (기본값: http://localhost:3100)
+    - LANGFUSE_HOST: Langfuse 서버 URL (명시 필요)
 
     @author llm-mcp
     @since 2026-01
@@ -33,10 +33,9 @@ type config = {
 let load_config () =
   let secret = Sys.getenv_opt "LANGFUSE_SECRET_KEY" in
   let public = Sys.getenv_opt "LANGFUSE_PUBLIC_KEY" in
-  let host = Sys.getenv_opt "LANGFUSE_HOST"
-    |> Option.value ~default:"http://localhost:3100" in
-  match secret, public with
-  | Some sk, Some pk ->
+  let host = Sys.getenv_opt "LANGFUSE_HOST" |> Option.value ~default:"" in
+  match secret, public, host with
+  | Some sk, Some pk, host when String.trim host <> "" ->
       { secret_key = sk; public_key = pk; host; enabled = true }
   | _ ->
       { secret_key = ""; public_key = ""; host; enabled = false }

--- a/lib/mcp_client_eio.ml
+++ b/lib/mcp_client_eio.ml
@@ -24,7 +24,10 @@ let next_id () =
   Atomic.fetch_and_add request_id 1
 
 (** Default MASC-MCP endpoint *)
-let masc_mcp_url = "http://127.0.0.1:8935"
+let masc_mcp_url () =
+  match Sys.getenv_opt "MASC_MCP_URL" with
+  | Some value when String.trim value <> "" -> String.trim value
+  | _ -> failwith "MASC_MCP_URL is required"
 
 (** {1 JSON-RPC Helpers} *)
 
@@ -171,7 +174,7 @@ let list_tools t ~url =
 
 (** Call MASC tool *)
 let call_masc t ~tool_name ~arguments =
-  call_tool t ~url:masc_mcp_url ~tool_name ~arguments
+  call_tool t ~url:(masc_mcp_url ()) ~tool_name ~arguments
 
 (** {1 Result Formatting} *)
 

--- a/lib/tool_config.ml
+++ b/lib/tool_config.ml
@@ -27,39 +27,39 @@ type mcp_server_config = {
   server_type: string;  (* "http" or "stdio" *)
 }
 
-(* Parse ~/.mcp.json to get external MCP server configs *)
+let config_path_opt () =
+  match Sys.getenv_opt "LLM_MCP_CONFIG_PATH" with
+  | Some path when String.trim path <> "" -> Some (String.trim path)
+  | _ ->
+      (match Sys.getenv_opt "MCP_CONFIG_PATH" with
+       | Some path when String.trim path <> "" -> Some (String.trim path)
+       | _ -> None)
+
+(* Parse external MCP config from an explicit config path only. *)
 let parse_mcp_config () : mcp_server_config list =
-  let home = Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp" in
-  let config_paths = [
-    Filename.concat home "me/.mcp.json";
-    Filename.concat home ".mcp.json";
-  ] in
-  let rec try_paths = function
-    | [] -> []
-    | path :: rest ->
-        try
-          let content = In_channel.with_open_text path In_channel.input_all in
-          let json = Yojson.Safe.from_string content in
-          let open Yojson.Safe.Util in
-          let servers = json |> member "mcpServers" |> to_assoc in
-          List.filter_map (fun (name, config) ->
-            let url = config |> member "url" |> to_string_option in
-            let command = config |> member "command" |> to_string_option in
-            let args = match config |> member "args" with
-              | `List l -> List.filter_map to_string_option l
-              | _ -> []
-            in
-            let server_type = config |> member "type" |> to_string_option |> Option.value ~default:"stdio" in
-            (* Include both HTTP and stdio servers *)
-            match server_type, url, command with
-            | "http", Some u, _ -> Some { name; url = Some u; command = None; args = []; server_type }
-            | "stdio", _, Some cmd -> Some { name; url = None; command = Some cmd; args; server_type }
-            | _, _, Some cmd -> Some { name; url = None; command = Some cmd; args; server_type = "stdio" }
-            | _ -> None
-          ) servers
-        with _ -> try_paths rest
-  in
-  try_paths config_paths
+  match config_path_opt () with
+  | None -> []
+  | Some path ->
+      try
+        let content = In_channel.with_open_text path In_channel.input_all in
+        let json = Yojson.Safe.from_string content in
+        let open Yojson.Safe.Util in
+        let servers = json |> member "mcpServers" |> to_assoc in
+        List.filter_map (fun (name, config) ->
+          let url = config |> member "url" |> to_string_option in
+          let command = config |> member "command" |> to_string_option in
+          let args = match config |> member "args" with
+            | `List l -> List.filter_map to_string_option l
+            | _ -> []
+          in
+          let server_type = config |> member "type" |> to_string_option |> Option.value ~default:"stdio" in
+          match server_type, url, command with
+          | "http", Some u, _ -> Some { name; url = Some u; command = None; args = []; server_type }
+          | "stdio", _, Some cmd -> Some { name; url = None; command = Some cmd; args; server_type }
+          | _, _, Some cmd -> Some { name; url = None; command = Some cmd; args; server_type = "stdio" }
+          | _ -> None
+        ) servers
+      with _ -> []
 
 (* Cached MCP server configs *)
 let mcp_servers = lazy (parse_mcp_config ())

--- a/lib/tool_parsers.ml
+++ b/lib/tool_parsers.ml
@@ -567,40 +567,26 @@ let build_gemini_cmd args =
   | _ -> Error "Invalid args for Gemini"
 
 let default_me_root () =
-  let home = Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp" in
-  Filename.concat home "me"
-
-let find_repo_root me_root =
   match Sys.getenv_opt "LLM_MCP_REPO_ROOT" with
-  | Some path -> path
-  | None ->
-      let candidates =
-        [Filename.concat me_root "llm-mcp"; Filename.concat me_root "workspace/llm-mcp"]
-      in
-      match List.find_opt Sys.file_exists candidates with
-      | Some path -> path
-      | None ->
-          let workspace = Filename.concat me_root "workspace" in
-          let rec find_in_workspace entries =
-            match entries with
-            | [] -> None
-            | dir :: rest ->
-                let candidate = Filename.concat (Filename.concat workspace dir) "llm-mcp" in
-                if Sys.file_exists candidate then Some candidate else find_in_workspace rest
-          in
-          (match Sys.readdir workspace with
-          | entries -> (
-              match find_in_workspace (Array.to_list entries) with
-              | Some path -> path
-              | None -> Filename.concat me_root "workspace/llm-mcp")
-          | exception _ -> Filename.concat me_root "workspace/llm-mcp")
+  | Some path when String.trim path <> "" -> String.trim path
+  | _ -> (
+      match Sys.getenv_opt "DUNE_SOURCEROOT" with
+      | Some path when String.trim path <> "" -> String.trim path
+      | _ -> failwith "LLM_MCP_REPO_ROOT is required (tests may use DUNE_SOURCEROOT)")
+
+let find_repo_root _me_root =
+  match Sys.getenv_opt "LLM_MCP_REPO_ROOT" with
+  | Some path when String.trim path <> "" -> String.trim path
+  | _ -> (
+      match Sys.getenv_opt "DUNE_SOURCEROOT" with
+      | Some path when String.trim path <> "" -> String.trim path
+      | _ -> failwith "LLM_MCP_REPO_ROOT is required (tests may use DUNE_SOURCEROOT)")
 
 (** Build Claude CLI command *)
 let build_claude_cmd args =
   match args with
   | Claude { prompt; model; long_context; system_prompt; output_format; allowed_tools; _ } ->
-      let me_root = Sys.getenv_opt "ME_ROOT" |> Option.value ~default:(default_me_root ()) in
-      let repo_root = find_repo_root me_root in
+      let repo_root = find_repo_root "" in
       let wrapper = Filename.concat repo_root "scripts/claude-wrapper.sh" in
       let cmd = [wrapper; "-p"; "--model"; model] in
       (* --betas context-1m enables 1M context but requires API key (charges apply)
@@ -700,11 +686,23 @@ let build_ollama_curl_cmd ?(force_stream=None) args =
             in
             ("/api/generate", payload)
       in
-      let url = "http://localhost:11434" ^ endpoint in
-      if stream_val then
-        Ok ["curl"; "-sN"; url; "-d"; json_payload]
+      let base_url =
+        match Sys.getenv_opt "OLLAMA_BASE_URL" with
+        | Some value when String.trim value <> "" -> String.trim value
+        | _ -> ""
+      in
+      if base_url = "" then Error "OLLAMA_BASE_URL is required for Ollama requests"
       else
-        Ok ["curl"; "-s"; url; "-d"; json_payload]
+        let trimmed =
+          if String.ends_with ~suffix:"/" base_url
+          then String.sub base_url 0 (String.length base_url - 1)
+          else base_url
+        in
+        let url = trimmed ^ endpoint in
+        if stream_val then
+          Ok ["curl"; "-sN"; url; "-d"; json_payload]
+        else
+          Ok ["curl"; "-s"; url; "-d"; json_payload]
   | _ -> Error "Invalid args for Ollama"
 
 (** {1 Response Parsers} *)

--- a/lib/tools_agentic_eio.ml
+++ b/lib/tools_agentic_eio.ml
@@ -2,7 +2,7 @@ open Printf
 open Types
 open Cli_runner_eio
 
-let ollama_base_url = Tools_ollama_agentic.base_url
+let ollama_base_url () = Tools_ollama_agentic.base_url ()
 
 type agent_message = Tools_ollama_agentic.agent_message = {
   role : string;
@@ -16,7 +16,7 @@ let build_agentic_request = Tools_ollama_agentic.build_chat_request
 
 let call_ollama_chat_eio ~sw ~proc_mgr ~clock ~timeout request_json =
   let body = Yojson.Safe.to_string request_json in
-  let url = ollama_base_url ^ "/api/chat" in
+  let url = ollama_base_url () ^ "/api/chat" in
   let result = run_command ~sw ~proc_mgr ~clock ~timeout "curl" [
     "-s"; "-X"; "POST"; url;
     "-H"; "Content-Type: application/json";

--- a/lib/tools_ollama_agentic.ml
+++ b/lib/tools_ollama_agentic.ml
@@ -5,7 +5,10 @@
 *)
 
 (** Ollama API endpoint *)
-let base_url = "http://127.0.0.1:11434"
+let base_url () =
+  match Sys.getenv_opt "OLLAMA_BASE_URL" with
+  | Some value when String.trim value <> "" -> String.trim value
+  | _ -> failwith "OLLAMA_BASE_URL is required"
 
 (** Conversation message type for agentic loop *)
 type agent_message = {

--- a/lib/tools_ollama_agentic.mli
+++ b/lib/tools_ollama_agentic.mli
@@ -1,7 +1,7 @@
 (** Tools Ollama Agentic - Pure helpers for Ollama agentic execution *)
 
 (** Ollama API endpoint *)
-val base_url : string
+val base_url : unit -> string
 
 (** Conversation message type for agentic loop *)
 type agent_message = {

--- a/scripts/chain-heartbeat.py
+++ b/scripts/chain-heartbeat.py
@@ -25,7 +25,7 @@ import urllib.request
 from typing import Any
 
 
-DEFAULT_MCP_URL = os.getenv("LLM_MCP_URL", "http://localhost:8932/mcp")
+DEFAULT_MCP_URL = os.getenv("LLM_MCP_URL", "")
 DEFAULT_MCP_API_KEY = os.getenv("LLM_MCP_API_KEY", "") or os.getenv("MCP_API_KEY", "")
 DEFAULT_INTERVAL_S = int(os.getenv("LLM_MCP_CHAIN_HEARTBEAT_INTERVAL_S", "300"))
 DEFAULT_LOCK = os.getenv("LLM_MCP_CHAIN_HEARTBEAT_LOCK", "/tmp/llm-mcp-chain-heartbeat.lock")
@@ -346,6 +346,9 @@ def main() -> int:
     ap.add_argument("--stale-lock-after-s", type=int, default=3600)
     args = ap.parse_args()
 
+    if not args.mcp_url or not args.mcp_url.strip():
+        raise RuntimeError("LLM_MCP_URL or --mcp-url is required")
+
     cfg = load_config(args.config)
     jobs = validate_jobs(cfg)
 
@@ -386,4 +389,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/start-llm-mcp.sh
+++ b/start-llm-mcp.sh
@@ -10,11 +10,6 @@ set -e
 ULIMIT_NOFILE="${LLM_ULIMIT_NOFILE:-65536}"
 ulimit -n "$ULIMIT_NOFILE" >/dev/null 2>&1 || true
 
-# Load API keys from user environment
-if [ -f "$HOME/.zshenv" ]; then
-    source "$HOME/.zshenv" 2>/dev/null || true
-fi
-
 # Ensure OCaml environment
 if command -v opam >/dev/null 2>&1; then
     eval $(opam env)

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -165,10 +165,11 @@ let test_protect_preserves_exception () =
 
 (** {1 New Coverage Tests} *)
 
-(** Test me_root defaults to ~/me *)
 let test_me_root () =
-  let root = Common.me_root in
-  check bool "me_root is non-empty" true (String.length root > 0)
+  with_env "LLM_MCP_REPO_ROOT" (Some "/tmp/llm-mcp-root") (fun () ->
+    let root = Common.me_root in
+    check string "me_root from env" "/tmp/llm-mcp-root" root
+  )
 
 (** Test ensure_dir creates nested directories *)
 let test_ensure_dir () =

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -167,7 +167,7 @@ let test_protect_preserves_exception () =
 
 let test_me_root () =
   with_env "LLM_MCP_REPO_ROOT" (Some "/tmp/llm-mcp-root") (fun () ->
-    let root = Common.me_root () in
+    let root = Common.me_root in
     check string "me_root from env" "/tmp/llm-mcp-root" root
   )
 

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -167,7 +167,7 @@ let test_protect_preserves_exception () =
 
 let test_me_root () =
   with_env "LLM_MCP_REPO_ROOT" (Some "/tmp/llm-mcp-root") (fun () ->
-    let root = Common.me_root in
+    let root = Common.me_root () in
     check string "me_root from env" "/tmp/llm-mcp-root" root
   )
 

--- a/test/test_tool_parsers.ml
+++ b/test/test_tool_parsers.ml
@@ -410,24 +410,24 @@ let test_build_codex_cmd () =
   | Error e -> fail ("build_codex_cmd failed: " ^ e)
 
 let test_build_ollama_curl_cmd () =
-  let args = Ollama {
-    prompt = "Hello";
-    model = "devstral";
-    system_prompt = None;
-    temperature = 0.7;
-    timeout = 60;
-    stream = false;
-    tools = None;
-  } in
-  match Tool_parsers.build_ollama_curl_cmd args with
-  | Ok cmd_list ->
-      check bool "cmd starts with curl" true (List.hd cmd_list = "curl");
-      check bool "has silent flag" true (List.mem "-s" cmd_list);
-      check bool "has data flag" true (List.mem "-d" cmd_list);
-      check bool "has localhost url" true
-        (List.exists (fun s -> String.length s >= 21 &&
-          String.sub s 0 21 = "http://localhost:1143") cmd_list)
-  | Error e -> fail ("build_ollama_curl_cmd failed: " ^ e)
+  with_env "OLLAMA_BASE_URL" "https://ollama.example.test" (fun () ->
+    let args = Ollama {
+      prompt = "Hello";
+      model = "devstral";
+      system_prompt = None;
+      temperature = 0.7;
+      timeout = 60;
+      stream = false;
+      tools = None;
+    } in
+    match Tool_parsers.build_ollama_curl_cmd args with
+    | Ok cmd_list ->
+        check bool "cmd starts with curl" true (List.hd cmd_list = "curl");
+        check bool "has silent flag" true (List.mem "-s" cmd_list);
+        check bool "has data flag" true (List.mem "-d" cmd_list);
+        check bool "has configured url" true
+          (List.exists (fun s -> String.starts_with ~prefix:"https://ollama.example.test/api/generate" s) cmd_list)
+    | Error e -> fail ("build_ollama_curl_cmd failed: " ^ e))
 
 (* {1Thinking Prompt Prefix Test} *)
 
@@ -1189,58 +1189,61 @@ let () =
 
     "build_ollama_curl_cmd_tools", [
       test_case "with tools" `Quick (fun () ->
-        let tool : Types.tool_schema = {
-          name = "get_weather"; description = "Get weather";
-          input_schema = `Assoc [("type", `String "object")];
-        } in
-        let args = Ollama {
-          prompt = "What is the weather?";
-          model = "devstral";
-          system_prompt = Some "You are helpful";
-          temperature = 0.7;
-          timeout = 60;
-          stream = false;
-          tools = Some [tool];
-        } in
-        match Tool_parsers.build_ollama_curl_cmd args with
-        | Ok cmd_list ->
-          check bool "cmd starts with curl" true (List.hd cmd_list = "curl");
-          (* tools branch uses /api/chat endpoint *)
-          let url = List.find (fun s -> String.length s > 4 && String.sub s 0 4 = "http") cmd_list in
-          check bool "chat endpoint" true (String.length url > 0 &&
-            let suffix = "/api/chat" in
-            let slen = String.length suffix in
-            String.length url >= slen &&
-            String.sub url (String.length url - slen) slen = suffix)
-        | Error e -> fail ("build failed: " ^ e));
+        with_env "OLLAMA_BASE_URL" "https://ollama.example.test" (fun () ->
+          let tool : Types.tool_schema = {
+            name = "get_weather"; description = "Get weather";
+            input_schema = `Assoc [("type", `String "object")];
+          } in
+          let args = Ollama {
+            prompt = "What is the weather?";
+            model = "devstral";
+            system_prompt = Some "You are helpful";
+            temperature = 0.7;
+            timeout = 60;
+            stream = false;
+            tools = Some [tool];
+          } in
+          match Tool_parsers.build_ollama_curl_cmd args with
+          | Ok cmd_list ->
+            check bool "cmd starts with curl" true (List.hd cmd_list = "curl");
+            (* tools branch uses /api/chat endpoint *)
+            let url = List.find (fun s -> String.length s > 4 && String.sub s 0 4 = "http") cmd_list in
+            check bool "chat endpoint" true (String.length url > 0 &&
+              let suffix = "/api/chat" in
+              let slen = String.length suffix in
+              String.length url >= slen &&
+              String.sub url (String.length url - slen) slen = suffix)
+          | Error e -> fail ("build failed: " ^ e)));
       test_case "streaming" `Quick (fun () ->
-        let args = Ollama {
-          prompt = "Hi"; model = "devstral"; system_prompt = None;
-          temperature = 0.7; timeout = 60; stream = true; tools = None;
-        } in
-        match Tool_parsers.build_ollama_curl_cmd args with
-        | Ok cmd_list ->
-          check bool "has -sN flag" true (List.mem "-sN" cmd_list)
-        | Error e -> fail ("build failed: " ^ e));
+        with_env "OLLAMA_BASE_URL" "https://ollama.example.test" (fun () ->
+          let args = Ollama {
+            prompt = "Hi"; model = "devstral"; system_prompt = None;
+            temperature = 0.7; timeout = 60; stream = true; tools = None;
+          } in
+          match Tool_parsers.build_ollama_curl_cmd args with
+          | Ok cmd_list ->
+            check bool "has -sN flag" true (List.mem "-sN" cmd_list)
+          | Error e -> fail ("build failed: " ^ e)));
       test_case "with system_prompt no tools" `Quick (fun () ->
-        let args = Ollama {
-          prompt = "Hi"; model = "devstral";
-          system_prompt = Some "Be helpful";
-          temperature = 0.5; timeout = 60; stream = false; tools = None;
-        } in
-        match Tool_parsers.build_ollama_curl_cmd args with
-        | Ok cmd_list ->
-          (* No tools = /api/generate endpoint with system in JSON *)
-          let data = List.nth cmd_list (List.length cmd_list - 1) in
-          check bool "has system field" true
-            (let n = "\"system\"" in
-             let nlen = String.length n in
-             let dlen = String.length data in
-             if nlen > dlen then false
-             else let rec c i = if i > dlen - nlen then false
-               else if String.sub data i nlen = n then true else c (i+1)
-             in c 0)
-        | Error e -> fail ("build failed: " ^ e));
+        with_env "OLLAMA_BASE_URL" "https://ollama.example.test" (fun () ->
+          let args = Ollama {
+            prompt = "Hi"; model = "devstral";
+            system_prompt = Some "Be helpful";
+            temperature = 0.5; timeout = 60; stream = false; tools = None;
+          } in
+          match Tool_parsers.build_ollama_curl_cmd args with
+          | Ok cmd_list ->
+            (* No tools = /api/generate endpoint with system in JSON *)
+            let data = List.nth cmd_list (List.length cmd_list - 1) in
+            check bool "has system field" true
+              (let n = "\"system\"" in
+               let nlen = String.length n in
+               let dlen = String.length data in
+               if nlen > dlen then false
+               else let rec c i = if i > dlen - nlen then false
+                 else if String.sub data i nlen = n then true else c (i+1)
+               in c 0)
+          | Error e -> fail ("build failed: " ^ e)));
     ];
 
     (* {1Tool calls to JSON} *)
@@ -1332,15 +1335,27 @@ let () =
 
     "default_env_funcs", [
       test_case "default_me_root" `Quick (fun () ->
-        let root = Tool_parsers.default_me_root () in
-        check bool "ends with me" true
-          (let suf = "me" in
-           let slen = String.length suf in
-           String.length root >= slen &&
-           String.sub root (String.length root - slen) slen = suf));
+        let old = Sys.getenv_opt "LLM_MCP_REPO_ROOT" in
+        Unix.putenv "LLM_MCP_REPO_ROOT" "/tmp/llm-mcp-root";
+        Fun.protect
+          ~finally:(fun () ->
+            match old with
+            | Some v -> Unix.putenv "LLM_MCP_REPO_ROOT" v
+            | None -> Unix.putenv "LLM_MCP_REPO_ROOT" "")
+          (fun () ->
+            let root = Tool_parsers.default_me_root () in
+            check string "explicit repo root" "/tmp/llm-mcp-root" root));
       test_case "find_repo_root" `Quick (fun () ->
-        let root = Tool_parsers.find_repo_root "/nonexistent/path" in
-        check bool "returns string" true (String.length root > 0));
+        let old = Sys.getenv_opt "LLM_MCP_REPO_ROOT" in
+        Unix.putenv "LLM_MCP_REPO_ROOT" "/tmp/llm-mcp-root";
+        Fun.protect
+          ~finally:(fun () ->
+            match old with
+            | Some v -> Unix.putenv "LLM_MCP_REPO_ROOT" v
+            | None -> Unix.putenv "LLM_MCP_REPO_ROOT" "")
+          (fun () ->
+            let root = Tool_parsers.find_repo_root "/nonexistent/path" in
+            check string "returns configured root" "/tmp/llm-mcp-root" root));
     ];
 
     (* {1Chain run with different input formats} *)

--- a/tools/chain-editor/index.html
+++ b/tools/chain-editor/index.html
@@ -2189,12 +2189,23 @@
       document.querySelector('[data-tab="output"]').click();
     }
 
+    function mcpBaseUrl() {
+      const override = window.localStorage.getItem('llmMcpUrl');
+      if (override && override.trim()) return override.trim().replace(/\/$/, '');
+      return '';
+    }
+
+    function mcpToolUrl() {
+      const base = mcpBaseUrl();
+      return base ? `${base}/mcp` : '/mcp';
+    }
+
     async function validateChain() {
       const mermaid = generateMermaidRaw();
       const hasChain = !!state.chainFull;
       setStatus('Validating (strict)...');
       try {
-        const res = await fetch('http://localhost:8932/mcp', {
+        const res = await fetch(mcpToolUrl(), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -2241,7 +2252,7 @@
       setStatus('Running...');
 
       try {
-        const res = await fetch('http://localhost:8932/mcp', {
+        const res = await fetch(mcpToolUrl(), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({


### PR DESCRIPTION
## Summary
- remove implicit local path and localhost fallbacks from runtime/startup/browser boundaries
- require explicit repo/config/base-url inputs where runtime used to guess from the local machine
- update focused tests for the new contract

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/llm-mcp/.worktrees/codex-runtime-boundary-pass1
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/llm-mcp/.worktrees/codex-runtime-boundary-pass1 ./test/test_common.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/llm-mcp/.worktrees/codex-runtime-boundary-pass1 ./test/test_tool_parsers.exe